### PR TITLE
add into_result on Array, add Result#match

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,6 +7,7 @@
 #+tags:
 
 * Summary
+
 =monad-oxide= is a Ruby take on Monads seen in [[https://www.rust-lang.org/][Rust's]] [[https://doc.rust-lang.org/stable/std/][=Std=]] package. Primarily
 this means [[https://doc.rust-lang.org/std/result/enum.Result.html#][=Result=]] and [[https://doc.rust-lang.org/std/option/enum.Option.html][=Option=]].
 
@@ -25,6 +26,9 @@ functional error handling. In this library, =Either= is essentially the same as
 =Result=, and =Maybe= the same as =Option=.
 
 * Examples
+:properties:
+:header-args: :ruby "nix-shell ./shell.nix --pure --run 'bundle exec ruby'" :dir .
+:end:
 
 Example Disclaimer:
 
@@ -37,17 +41,22 @@ production instances. If so, code defensively around their usages and try to use
 the methods sparingly.  Having a dedicated quarantine zone around your =unwrap=
 and =unwrap_err= is the most preferable.
 
+** map
+
 Changing the inner value with =map=:
-#+begin_src ruby
+#+begin_src ruby :results value :exports both
 require 'monad-oxide'
 
 MonadOxide.ok('test')
-  .map(->(s) { s.uppercase() })
+  .map(->(s) { s.upcase() })
   .unwrap() # 'test'
 #+end_src
 
+#+RESULTS:
+: TEST
+
 Changing the =Result= type based on input:
-#+begin_src ruby
+#+begin_src ruby :exports both
 require 'monad-oxide'
 
 MonadOxide.ok('test')
@@ -61,8 +70,13 @@ MonadOxide.ok('test')
   .unwrap_err() # The above ArgumentError.
 #+end_src
 
+#+RESULTS:
+: #<ArgumentError: Can't have 'e' in test data.>
+
+** inspect
+
 Inspecting a value in the chain without changing it:
-#+begin_src ruby
+#+begin_src ruby :exports both
 require 'logger'
 require 'monad-oxide'
 
@@ -80,8 +94,52 @@ MonadOxide.ok('test')
   .unwrap_err() # The above ArgumentError.
 #+end_src
 
+#+RESULTS:
+: #<ArgumentError: Can't have 'e' in test data.>
+
+** arrays
+
+You can use =#into_result= to convert an =Array= of =Results= to =Result= of an
+=Array=.
+
+#+begin_src ruby :results value verbatim :exports both
+require 'monad-oxide'
+
+[
+  MonadOxide.ok('foo'),
+  MonadOxide.ok('bar'),
+]
+  .into_result()
+  .unwrap()
+#+end_src
+
+#+RESULTS:
+: ["foo", "bar"]
+
+=#into_result= will provide an =Err= if any of the elements in the =Array= are
+=Err=.
+
+#+begin_src ruby :results value verbatim :exports both
+require 'monad-oxide'
+
+[
+  MonadOxide.ok('foo'),
+  MonadOxide.err('bar'),
+  MonadOxide.ok('baz'),
+  MonadOxide.err('qux'),
+]
+  .into_result()
+  .unwrap_err()
+#+end_src
+
+#+RESULTS:
+: ["bar", "qux"]
+
+** complex operations
+
 Complex operation:
-#+begin_src ruby
+
+#+begin_src ruby :exports both
 require 'logger'
 require 'monad-oxide'
 
@@ -115,3 +173,12 @@ MonadOxide.ok('test')
 
 https://github.com/mxhold/opted has similar aims to =monad-oxide= - essentially
 a Rust port of the =Result= type.
+* COMMENT Quirks in Documentation
+
+I can't make repeating =:header-args:= to split up the lines, despite there
+seeming to be _some_ examples indicating otherwise.
+
+=:exports both= doesn't work in =:header-args:= and must be applied individually
+to each code block.
+
+These may have bugs and I should research that at some point.

--- a/lib/array.rb
+++ b/lib/array.rb
@@ -1,0 +1,28 @@
+# Reopen Array to add some handy capabilities idoimatic to Ruby.
+class Array
+
+  ##
+  # Take an Array of Results and convert them to a single Result whose value is
+  # an Array of Ok or Err values. Ok Results will have only Ok values, and Err
+  # Results will have only Err values. A single Err in the input Array will
+  # convert the entire Result into an Err.
+  #
+  # @return [MonadOxide::Result<Array<V>, Array<E>>] A Result whose value is an
+  # array of all of the Oks or Errs in the Array.
+  def into_result()
+    tracker = {
+      oks: [],
+      errs: [],
+    }
+    self.each do |result|
+      result.match({
+        MonadOxide::Ok => ->(x) { tracker[:oks].push(x) },
+        MonadOxide::Err => ->(e) { tracker[:errs].push(e) },
+      })
+    end
+    tracker[:errs].empty?() ?
+      MonadOxide.ok(tracker[:oks]) :
+      MonadOxide.err(tracker[:errs])
+  end
+
+end

--- a/lib/array_spec.rb
+++ b/lib/array_spec.rb
@@ -1,0 +1,81 @@
+describe Array do
+
+  context '#into_result' do
+
+    context 'all Oks' do
+
+      it 'returns a single Ok' do
+        result = [
+          MonadOxide.ok('foo'),
+          MonadOxide.ok('bar'),
+          MonadOxide.ok('baz'),
+        ].into_result()
+        expect(result).to(be_a_kind_of(MonadOxide::Ok))
+      end
+
+      it 'returns a single Ok that has an array of Ok data' do
+        result = [
+          MonadOxide.ok('foo'),
+          MonadOxide.ok('bar'),
+          MonadOxide.ok('baz'),
+        ].into_result()
+        expect(result.unwrap()).to(eq(['foo', 'bar', 'baz']))
+      end
+
+    end
+
+    context 'all Errs' do
+
+      it 'returns a single Err' do
+        result = [
+          MonadOxide.err(StandardError.new('foo')),
+          MonadOxide.err(StandardError.new('bar')),
+          MonadOxide.err(StandardError.new('baz')),
+        ].into_result()
+        expect(result).to(be_a_kind_of(MonadOxide::Err))
+      end
+
+      it 'returns a single Err that has an array of Err data' do
+        result = [
+          MonadOxide.err(StandardError.new('foo')),
+          MonadOxide.err(StandardError.new('bar')),
+          MonadOxide.err(StandardError.new('baz')),
+        ].into_result()
+        expect(result.unwrap_err().map(&:message)).to(eq(['foo', 'bar', 'baz']))
+      end
+
+    end
+
+    context 'mixed Oks and Errs' do
+
+      it 'returns a single Err' do
+        result = [
+          MonadOxide.ok('foo'),
+          MonadOxide.err(StandardError.new('bar')),
+          MonadOxide.ok('baz'),
+        ].into_result()
+        expect(result).to(be_a_kind_of(MonadOxide::Err))
+      end
+
+      it 'returns a single Err that has an array of Err data' do
+        result = [
+          MonadOxide.err(StandardError.new('foo')),
+          MonadOxide.err(StandardError.new('bar')),
+          MonadOxide.ok('baz'),
+        ].into_result()
+        expect(result.unwrap_err().map(&:message)).to(eq(['foo', 'bar']))
+      end
+
+      it 'returns a single Err that has no Ok data' do
+        result = [
+          MonadOxide.err(StandardError.new('foo')),
+          MonadOxide.err(StandardError.new('bar')),
+          MonadOxide.ok('baz'),
+        ].into_result()
+        expect(result.unwrap_err().map(&:message)).not_to(include('baz'))
+      end
+    end
+
+  end
+
+end

--- a/lib/monad-oxide.rb
+++ b/lib/monad-oxide.rb
@@ -1,6 +1,7 @@
 require_relative './result'
 require_relative './err'
 require_relative './ok'
+require_relative './array'
 require_relative './version'
 
 ##

--- a/lib/result.rb
+++ b/lib/result.rb
@@ -100,6 +100,34 @@ module MonadOxide
     end
 
     ##
+    # In the case of `Err', applies `f' or the block over the `Exception' and
+    # returns the same `Err'. No changes are applied. This is ideal for logging.
+    # For `Ok', this method falls through. Exceptions raised during these
+    # transformations will return an `Err' with the Exception.
+    # @param f [Proc<A, B>] The function to call. Could be a block instead.
+    #          Takes an [A=Exception] the return is ignored.
+    # @yield Will yield a block that takes an A the return is ignored. Same as
+    #        `f' parameter.
+    # @return [Result<A>] returns self.
+    def inspect_err(f=nil, &block)
+      Err.new(ResultMethodNotImplementedError.new())
+    end
+
+    ##
+    # In the case of `Ok', applies `f' or the block over the data and returns
+    # the same `Ok'. No changes are applied. This is ideal for logging.  For
+    # `Err', this method falls through. Exceptions raised during these
+    # transformations will return an `Err' with the Exception.
+    # @param f [Proc<A, B>] The function to call. Could be a block instead.
+    #          Takes an [A] the return is ignored.
+    # @yield Will yield a block that takes an A the return is ignored. Same as
+    #        `f' parameter.
+    # @return [Result<A>] returns self.
+    def inspect_ok(f=nil, &block)
+      Err.new(ResultMethodNotImplementedError.new())
+    end
+
+    ##
     # In the case of `Ok', applies `f' or the block over the data and returns a
     # new new `Ok' with the returned value. For `Err', this method falls
     # through. Exceptions raised during these transformations will return an
@@ -132,31 +160,23 @@ module MonadOxide
     end
 
     ##
-    # In the case of `Err', applies `f' or the block over the `Exception' and
-    # returns the same `Err'. No changes are applied. This is ideal for logging.
-    # For `Ok', this method falls through. Exceptions raised during these
-    # transformations will return an `Err' with the Exception.
-    # @param f [Proc<A, B>] The function to call. Could be a block instead.
-    #          Takes an [A=Exception] the return is ignored.
-    # @yield Will yield a block that takes an A the return is ignored. Same as
-    #        `f' parameter.
-    # @return [Result<A>] returns self.
-    def inspect_err(f=nil, &block)
-      Err.new(ResultMethodNotImplementedError.new())
-    end
-
-    ##
-    # In the case of `Ok', applies `f' or the block over the data and returns
-    # the same `Ok'. No changes are applied. This is ideal for logging.  For
-    # `Err', this method falls through. Exceptions raised during these
-    # transformations will return an `Err' with the Exception.
-    # @param f [Proc<A, B>] The function to call. Could be a block instead.
-    #          Takes an [A] the return is ignored.
-    # @yield Will yield a block that takes an A the return is ignored. Same as
-    #        `f' parameter.
-    # @return [Result<A>] returns self.
-    def inspect_ok(f=nil, &block)
-      Err.new(ResultMethodNotImplementedError.new())
+    # Use pattern matching to work with both Ok and Err variants. This is useful
+    # when it is desirable to have both variants handled in the same location.
+    # It can also be useful when either variant can coerced into a non-Result
+    # type.
+    #
+    # Ruby has no built-in pattern matching, but the next best thing is a Hash
+    # using the Result classes themselves as the keys.
+    #
+    # Tests for this are found in Ok and Err's tests.
+    #
+    # @param matcher [Hash<Class, Proc<T | E, R>] matcher The matcher to match
+    # upon.
+    # @option matcher [Proc] MonadOxide::Ok The branch to execute for Ok.
+    # @option matcher [Proc] MonadOxide::Err The branch to execute for Err.
+    # @return [R] The return value of the executed Proc.
+    def match(matcher)
+      matcher[self.class].call(@data)
     end
 
     ##


### PR DESCRIPTION
This adds an `#into_result` on `Array`. This way an `Array` of `Results` can easily be coerced into a `Result` of an `Array`. If any of the members are an `Err` then the returned `Result` is an `Err` of all of the `Err` values as an `Array`. Otherwise it returns an `Ok` of all of the `Ok` values, as an `Array`. To accommodate this, `Err` has been relaxed and now accepts any value, not just `Exceptions`.

To help build this functionality, `#match` had to be added to `Result`.

Earmarked in this change is:
1. Some methods and tests were rearranged for lexicographical order.
2. Parts of the `README` are now executable!