### PR TITLE
add unwrap_or to Result

### DIFF
--- a/README.org
+++ b/README.org
@@ -97,6 +97,101 @@ MonadOxide.ok('test')
 #+RESULTS:
 : #<ArgumentError: Can't have 'e' in test data.>
 
+** unwrapping
+
+Unwrapping is the act of accessing the value inside the =Result=. It is often
+considered dangerous because it raises exceptions - an action counter to the
+whole purpose of =monad-oxide=. However, there are variants documented below to
+make the operation safe.
+
+*** unwrap and unwrap_err
+
+=unwrap= and =unwrap_err= both access inner =Ok= and =Err= data, respectively.
+If the =Result= is mismatched (=unwrap= and =Err= or =unwrap_err= and =Ok=), an
+=MonadOxide::UnwrapError= is raised.
+
+It is recommended to only use this for debugging purposes and instead seek
+better, more functional uses in =Result= to work with the data in the =Result=.
+
+=Ok= with =unwrap= just gets the data.
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.ok('foo').unwrap()
+#+end_src
+
+#+RESULTS:
+: foo
+
+=Err= with =unwrap= raises =UnwrapError=:
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+begin
+  MonadOxide.err('foo').unwrap()
+rescue => e
+  e.inspect()
+end
+#+end_src
+
+#+RESULTS:
+: #<MonadOxide::UnwrapError: MonadOxide::Err with "foo" could not be unwrapped as an Ok.>
+
+=Ok= with =unwrap_err= raises =UnwrapError=:
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+begin
+  MonadOxide.ok('foo').unwrap_err()
+rescue => e
+  e.inspect()
+end
+#+end_src
+
+#+RESULTS:
+: #<MonadOxide::UnwrapError: MonadOxide::Ok with "foo" could not be unwrapped as an Err.>
+
+=Ok= with =unwrap= just gets the data.
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.err('foo').unwrap_err()
+#+end_src
+
+#+RESULTS:
+: foo
+
+*** unwrap_or
+
+=unwrap_or= provides a safe means of unwrapping via a fallback value that is
+provided to =unwrap_or=.
+
+For =Ok=, =unwrap_or= provides the value in the =Ok=.
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.ok('foo').unwrap_or('bar')
+#+end_src
+
+#+RESULTS:
+: foo
+
+For =Err=, =unwrap_or= provides the value passed to =unwrap_or=.
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.err('foo').unwrap_or('bar')
+#+end_src
+
+#+RESULTS:
+: bar
+
 ** arrays
 
 You can use =#into_result= to convert an =Array= of =Results= to =Result= of an

--- a/lib/err.rb
+++ b/lib/err.rb
@@ -166,5 +166,15 @@ module MonadOxide
       @data
     end
 
+    ##
+    # Safely unwrap the `Result`. In the case of `Err`, this returns the
+    # provided default value.
+    #
+    # @param [T] x The value that will be returned.
+    # @return [T] The `x` value.
+    def unwrap_or(x)
+      x
+    end
+
   end
 end

--- a/lib/err_spec.rb
+++ b/lib/err_spec.rb
@@ -437,4 +437,12 @@ describe MonadOxide::Err do
       ).to(eq('foo'))
     end
   end
+
+  context '#unwrap_or' do
+
+    it 'returns the passed data' do
+      expect(MonadOxide.err('foo').unwrap_or('bar')).to(eq('bar'))
+    end
+
+  end
 end

--- a/lib/ok.rb
+++ b/lib/ok.rb
@@ -123,5 +123,16 @@ module MonadOxide
         "#{self.class} with #{@data.inspect} could not be unwrapped as an Err.",
       )
     end
+
+    ##
+    # Safely unwrap the `Result`. In the case of `Ok`, this returns the
+    # data in the Ok.
+    #
+    # @param [B] x The value that will be returned.
+    # @return [A] The data in the Ok.
+    def unwrap_or(_)
+      @data
+    end
+
   end
 end

--- a/lib/ok_spec.rb
+++ b/lib/ok_spec.rb
@@ -404,4 +404,12 @@ describe MonadOxide::Ok do
       }.to(raise_error(MonadOxide::UnwrapError))
     end
   end
+
+  context '#unwrap_or' do
+
+    it 'returns the data from the Ok' do
+      expect(MonadOxide.ok('foo').unwrap_or('bar')).to(eq('foo'))
+    end
+
+  end
 end

--- a/lib/result.rb
+++ b/lib/result.rb
@@ -225,5 +225,16 @@ module MonadOxide
     def unwrap_err()
       Err.new(ResultMethodNotImplementedError.new())
     end
+
+    ##
+    # Attempt to safely access the `Result` data. This always returns a value
+    # instead of raising an Exception. In the case of `Ok`, the data is
+    # returned. In the case of `Err`, the value provided is returned.
+    # @param _ [B] The value to use for `Err`.
+    # @return [T|B] The inner data of this `Ok` or the passee value.
+    def unwrap_or(_)
+      Err.new(ResultMethodNotImplementedError.new())
+    end
+
   end
 end


### PR DESCRIPTION
This adds an `#unwrap_or` to `Result`. `#unwrap_or` is a safer cousin of `#unwrap`. It accomplishes this by requiring a fallback value which is returned in the case of `Err`.

Earmarked in these changes is additional documentation for `#unwrap` and `#unwrap_err`.