### PR TITLE
Add ok?/err? checks for rspec

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,8 +1,1 @@
-if type lorri &>/dev/null; then
-echo "direnv: using lorri"
-eval "$(lorri direnv)"
-else
-# fall back to using direnv's builtin nix support
-# to prevent bootstrapping problems.
-use nix
-fi
+use flake

--- a/README.org
+++ b/README.org
@@ -27,7 +27,7 @@ functional error handling. In this library, =Either= is essentially the same as
 
 * Examples
 :properties:
-:header-args: :ruby "nix-shell ./shell.nix --pure --run 'bundle exec ruby'" :dir .
+:header-args: :ruby "nix develop '.#default' --command bash -c 'bundle exec ruby'" :dir .
 :end:
 
 Example Disclaimer:
@@ -96,6 +96,61 @@ MonadOxide.ok('test')
 
 #+RESULTS:
 : #<ArgumentError: Can't have 'e' in test data.>
+** =<kind>?= checks
+
+You can check to see if you're working with an =Ok= or =Err= with =ok?= and
+=err?=.  Generally these should see the most use with your unit tests in the
+form of =expect(foo).to(be_ok())= and =expect(bar).to(be_err()))=.  It is
+advised to favor mechanisms like =#match= or one of the safe =#unwrap= variants
+when attempting to do conditional work based on the =Result= subtype, rather
+than adding branching paths.
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+MonadOxide.ok('foo').ok?()
+#+end_src
+
+#+RESULTS:
+: true
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+MonadOxide.ok('foo').err?()
+#+end_src
+
+#+RESULTS:
+: false
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+MonadOxide.err('foo').ok?()
+#+end_src
+
+#+RESULTS:
+: false
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+MonadOxide.err('foo').err?()
+#+end_src
+
+#+RESULTS:
+: true
+
+*** with =rspec=
+
+And with =rspec=.  There's some difficulty in finding the right incantation to
+call into =rspec= without actually running =rspec=, or getting =rspec= to be the
+"ruby" runner for =org-babel=, so results aren't shown.
+
+#+begin_src ruby :results none :exports code
+require 'monad-oxide'
+expect(MonadOxide.ok('foo')).to(be_ok) # Pass.
+expect(MonadOxide.ok('foo')).to(be_err) # Fail.
+expect(MonadOxide.err('foo')).to(be_ok) # Fail.
+expect(MonadOxide.err('foo')).to(be_err) # Pass.
+#+end_src
+
 
 ** unwrapping
 
@@ -268,6 +323,7 @@ MonadOxide.ok('test')
 
 https://github.com/mxhold/opted has similar aims to =monad-oxide= - essentially
 a Rust port of the =Result= type.
+
 * COMMENT Quirks in Documentation
 
 I can't make repeating =:header-args:= to split up the lines, despite there

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1715220225,
+        "narHash": "sha256-X0xvboLSjfC5s/M1yuPdSdc6yzKV8536hTTWCSKF5Xc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac34158a823c7596e0106c806d0b7df47885fa73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "";
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs/nixpkgs-unstable;
+  };
+
+  outputs = { self, nixpkgs }@inputs: {
+
+    devShells.aarch64-darwin.default = let
+      system = "aarch64-darwin";
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+    in pkgs.mkShell {
+      buildInputs = [
+        pkgs.bash
+        pkgs.ruby
+        pkgs.bundler
+      ];
+    };
+
+  };
+}

--- a/lib/err.rb
+++ b/lib/err.rb
@@ -66,6 +66,17 @@ module MonadOxide
     end
 
     ##
+    # Identifies that this is an `Err`.
+    # For counterparts:
+    # @see MonadOxide::Ok#ok?
+    # @see MonadOxide::Ok#err?
+    # @see MonadOxide::Err#ok?
+    # @return [Boolean] `true` because this is an `Err`.
+    def err?()
+      true
+    end
+
+    ##
     # Applies `f' or the block over the `Exception' and returns the same `Err'.
     # No changes are applied. This is ideal for logging.  Exceptions raised
     # during these transformations will return an `Err' with the Exception.
@@ -120,6 +131,17 @@ module MonadOxide
       rescue => e
         self.class.new(e)
       end
+    end
+
+    ##
+    # Identifies that this is not an `Ok`.
+    # For counterparts:
+    # @see MonadOxide::Ok#ok?
+    # @see MonadOxide::Ok#err?
+    # @see MonadOxide::Err#err?
+    # @return [Boolean] `false` because this is not an `Ok`.
+    def ok?()
+      false
     end
 
     ##

--- a/lib/err_spec.rb
+++ b/lib/err_spec.rb
@@ -102,6 +102,11 @@ describe MonadOxide::Err do
 
   end
 
+  context '#err?' do
+    it 'is an Err' do
+      expect(MonadOxide.err(StandardError.new('foo'))).to(be_err)
+    end
+  end
 
   context '#inspect_err' do
     context 'with blocks' do
@@ -304,6 +309,12 @@ describe MonadOxide::Err do
       ).to(eq('FOO'))
     end
 
+  end
+
+  context '#ok?' do
+    it 'is not an Ok' do
+      expect(MonadOxide.err(StandardError.new('foo'))).not_to(be_ok)
+    end
   end
 
   context '#or_else' do

--- a/lib/ok.rb
+++ b/lib/ok.rb
@@ -41,6 +41,17 @@ module MonadOxide
     end
 
     ##
+    # Identifies that this is not an `Err`.
+    # For counterparts:
+    # @see MonadOxide::Ok#ok?
+    # @see MonadOxide::Err#ok?
+    # @see MonadOxide::Err#err?
+    # @return [Boolean] `false` because this is not an `Err`.
+    def err?()
+      false
+    end
+
+    ##
     # Falls through. @see Result#inspect_err for how this is handled in either
     # Result case, and @see Err.inspect_err for how this is handled in the Err
     # case.
@@ -94,6 +105,17 @@ module MonadOxide
     # @return [Result<A>] This `Ok'.
     def map_err(f=nil, &block)
       self
+    end
+
+    ##
+    # Identifies that this is an `Ok`.
+    # For counterparts:
+    # @see MonadOxide::Ok#err?
+    # @see MonadOxide::Err#ok?
+    # @see MonadOxide::Err#err?
+    # @return [Boolean] `true` because this is an `Ok`.
+    def ok?()
+      true
     end
 
     ##

--- a/lib/ok_spec.rb
+++ b/lib/ok_spec.rb
@@ -113,6 +113,12 @@ describe MonadOxide::Ok do
 
   end
 
+  context '#err?' do
+    it 'is not an Err' do
+      expect(MonadOxide.ok('foo')).not_to(be_err)
+    end
+  end
+
   context '#inspect_err' do
     context 'with blocks' do
       it 'does nothing with the block' do
@@ -388,6 +394,12 @@ describe MonadOxide::Ok do
             .unwrap()
         ).to(eq('foo'))
       end
+    end
+  end
+
+  context '#ok?' do
+    it 'is an Ok' do
+      expect(MonadOxide.ok('foo')).to(be_ok)
     end
   end
 

--- a/lib/result.rb
+++ b/lib/result.rb
@@ -57,6 +57,13 @@ module MonadOxide
     end
 
     ##
+    # Determine if this is a MonadOxide::Err.
+    # @return [Boolean] `true` if this is a MonadOxide::Err, `false` otherwise.
+    def err?()
+      false
+    end
+
+    ##
     # For `Ok', invokes `f' or the block with the data and returns the Result
     # returned from that. Exceptions raised during `f' or the block will return
     # an `Err<Exception>'.
@@ -177,6 +184,13 @@ module MonadOxide
     # @return [R] The return value of the executed Proc.
     def match(matcher)
       matcher[self.class].call(@data)
+    end
+
+    ##
+    # Determine if this is a MonadOxide::Ok.
+    # @return [Boolean] `true` if this is a MonadOxide::Ok, `false` otherwise.
+    def ok?()
+      false
     end
 
     ##

--- a/lib/result.rb
+++ b/lib/result.rb
@@ -57,20 +57,6 @@ module MonadOxide
     end
 
     ##
-    # Un-nest this `Result'. This implementation is shared between `Ok' and
-    # `Err'. In both cases, the structure's data is operated upon.
-    # @return [Result] If `A' is a `Result' (meaning this `Result` is nested),
-    # return the inner-most `Result', regardless of the depth of nesting.
-    # Otherwise return `self'.
-    def flatten()
-      if @data.kind_of?(Result)
-        return @data.flatten()
-      else
-        self
-      end
-    end
-
-    ##
     # For `Ok', invokes `f' or the block with the data and returns the Result
     # returned from that. Exceptions raised during `f' or the block will return
     # an `Err<Exception>'.
@@ -111,6 +97,20 @@ module MonadOxide
     # @return [Result<A>] returns self.
     def inspect_err(f=nil, &block)
       Err.new(ResultMethodNotImplementedError.new())
+    end
+
+    ##
+    # Un-nest this `Result'. This implementation is shared between `Ok' and
+    # `Err'. In both cases, the structure's data is operated upon.
+    # @return [Result] If `A' is a `Result' (meaning this `Result` is nested),
+    # return the inner-most `Result', regardless of the depth of nesting.
+    # Otherwise return `self'.
+    def flatten()
+      if @data.kind_of?(Result)
+        return @data.flatten()
+      else
+        self
+      end
     end
 
     ##

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,0 @@
-{ pkgs ? import <nixpkgs> {} }:
-
-with pkgs;
-
-mkShell {
-  nativeBuildInputs = [
-    ruby
-  ];
-}


### PR DESCRIPTION
This is broken into three parts:
1. I can't get `shell.nix` to work anymore, so it might as well use
`flake.nix`.
2. Move `#flatten` to the correct lexicographical location.
3. Introduce `MonadOxide::Result#ok?` and `MonadOxide::Result#err?`. This makes testing easier with rspec, and adds the convenience of just being able to check what is being dealt with in an idiomatic fashion.
It does have room for abuse, but documentation has added caution.