### PR TITLE
Add unwrap or else and unwrap err or else

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 # Attempts to ignore files specific to your configuration will be rejected.
 #
 # Please justify all ignore entries with comments.
+
+# Ignore generated Yard metadata.  This isn't the documentation itself.
+.yardoc

--- a/README.org
+++ b/README.org
@@ -162,8 +162,8 @@ make the operation safe.
 *** unwrap and unwrap_err
 
 =unwrap= and =unwrap_err= both access inner =Ok= and =Err= data, respectively.
-If the =Result= is mismatched (=unwrap= and =Err= or =unwrap_err= and =Ok=), an
-=MonadOxide::UnwrapError= is raised.
+If the =Result= is mismatched (=unwrap= with =Err= or =unwrap_err= with =Ok=),
+an =MonadOxide::UnwrapError= is raised.
 
 It is recommended to only use this for debugging purposes and instead seek
 better, more functional uses in =Result= to work with the data in the =Result=.
@@ -209,7 +209,7 @@ end
 #+RESULTS:
 : #<MonadOxide::UnwrapError: MonadOxide::Ok with "foo" could not be unwrapped as an Err.>
 
-=Ok= with =unwrap= just gets the data.
+=Err= with =unwrap_err= just gets the data.
 
 #+begin_src ruby :results value :exports both
 require 'monad-oxide'
@@ -246,6 +246,59 @@ MonadOxide.err('foo').unwrap_or('bar')
 
 #+RESULTS:
 : bar
+
+*** unwrap_or_else and unwrap_err_or_else
+
+=unwrap_or_else= and =unwrap_err_or_else= both access inner =Ok= and =Err= data,
+respectively.  If the =Result= is mismatched (=unwrap_or_else= with =Err= or
+=unwrap_err_or_else= with =Ok=), the provided function or block is evaluated and
+its return value is returned.
+
+This =unwrap= is safe because there is always a value returned.
+
+=Ok= with =unwrap_or_else= just gets the data.
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.ok('foo').unwrap_or_else(->() { 'bar' })
+#+end_src
+
+#+RESULTS:
+: foo
+
+=Err= with =unwrap_or_else= returns the value from the provided function:
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.err('foo').unwrap(->(){ 'bar' })
+#+end_src
+
+#+RESULTS:
+: bar
+
+=Ok= with =unwrap_err_or_else= returns the value from the provided function:
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.ok('foo').unwrap_err_or_else(->() { 'bar' })
+#+end_src
+
+#+RESULTS:
+: bar
+
+=Err= with =unwrap_err_or_else= just gets the data.
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.err('foo').unwrap_err(->() { 'bar' })
+#+end_src
+
+#+RESULTS:
+: foo
 
 ** arrays
 

--- a/README.org
+++ b/README.org
@@ -5,8 +5,12 @@
 #+language:  en
 #+file_tags:
 #+tags:
+#+auto_id:   t
 
 * Summary
+:PROPERTIES:
+:CUSTOM_ID: summary
+:END:
 
 =monad-oxide= is a Ruby take on Monads seen in [[https://www.rust-lang.org/][Rust's]] [[https://doc.rust-lang.org/stable/std/][=Std=]] package. Primarily
 this means [[https://doc.rust-lang.org/std/result/enum.Result.html#][=Result=]] and [[https://doc.rust-lang.org/std/option/enum.Option.html][=Option=]].
@@ -28,6 +32,7 @@ functional error handling. In this library, =Either= is essentially the same as
 * Examples
 :properties:
 :header-args: :ruby "nix develop '.#default' --command bash -c 'bundle exec ruby'" :dir .
+:CUSTOM_ID: examples
 :end:
 
 Example Disclaimer:
@@ -42,6 +47,9 @@ the methods sparingly.  Having a dedicated quarantine zone around your =unwrap=
 and =unwrap_err= is the most preferable.
 
 ** map
+:PROPERTIES:
+:CUSTOM_ID: examples--map
+:END:
 
 Changing the inner value with =map=:
 #+begin_src ruby :results value :exports both
@@ -74,6 +82,9 @@ MonadOxide.ok('test')
 : #<ArgumentError: Can't have 'e' in test data.>
 
 ** inspect
+:PROPERTIES:
+:CUSTOM_ID: examples--inspect
+:END:
 
 Inspecting a value in the chain without changing it:
 #+begin_src ruby :exports both
@@ -97,6 +108,9 @@ MonadOxide.ok('test')
 #+RESULTS:
 : #<ArgumentError: Can't have 'e' in test data.>
 ** =<kind>?= checks
+:PROPERTIES:
+:CUSTOM_ID: examples--=<kind>=-checks
+:END:
 
 You can check to see if you're working with an =Ok= or =Err= with =ok?= and
 =err?=.  Generally these should see the most use with your unit tests in the
@@ -138,6 +152,9 @@ MonadOxide.err('foo').err?()
 : true
 
 *** with =rspec=
+:PROPERTIES:
+:CUSTOM_ID: examples--=<kind>=-checks--with-=rspec=
+:END:
 
 And with =rspec=.  There's some difficulty in finding the right incantation to
 call into =rspec= without actually running =rspec=, or getting =rspec= to be the
@@ -153,6 +170,9 @@ expect(MonadOxide.err('foo')).to(be_err) # Pass.
 
 
 ** unwrapping
+:PROPERTIES:
+:CUSTOM_ID: examples--unwrapping
+:END:
 
 Unwrapping is the act of accessing the value inside the =Result=. It is often
 considered dangerous because it raises exceptions - an action counter to the
@@ -160,6 +180,9 @@ whole purpose of =monad-oxide=. However, there are variants documented below to
 make the operation safe.
 
 *** unwrap and unwrap_err
+:PROPERTIES:
+:CUSTOM_ID: examples--unwrapping--unwrap-and-unwrap_err
+:END:
 
 =unwrap= and =unwrap_err= both access inner =Ok= and =Err= data, respectively.
 If the =Result= is mismatched (=unwrap= with =Err= or =unwrap_err= with =Ok=),
@@ -221,6 +244,9 @@ MonadOxide.err('foo').unwrap_err()
 : foo
 
 *** unwrap_or
+:PROPERTIES:
+:CUSTOM_ID: examples--unwrapping--unwrap_or
+:END:
 
 =unwrap_or= provides a safe means of unwrapping via a fallback value that is
 provided to =unwrap_or=.
@@ -248,6 +274,9 @@ MonadOxide.err('foo').unwrap_or('bar')
 : bar
 
 *** unwrap_or_else and unwrap_err_or_else
+:PROPERTIES:
+:CUSTOM_ID: examples--unwrapping--unwrap_or_else-and-unwrap_err_or_else
+:END:
 
 =unwrap_or_else= and =unwrap_err_or_else= both access inner =Ok= and =Err= data,
 respectively.  If the =Result= is mismatched (=unwrap_or_else= with =Err= or
@@ -301,6 +330,9 @@ MonadOxide.err('foo').unwrap_err(->() { 'bar' })
 : foo
 
 ** arrays
+:PROPERTIES:
+:CUSTOM_ID: examples--arrays
+:END:
 
 You can use =#into_result= to convert an =Array= of =Results= to =Result= of an
 =Array=.
@@ -339,6 +371,9 @@ require 'monad-oxide'
 : ["bar", "qux"]
 
 ** complex operations
+:PROPERTIES:
+:CUSTOM_ID: examples--complex-operations
+:END:
 
 Complex operation:
 
@@ -373,11 +408,92 @@ MonadOxide.ok('test')
 #+end_src
 
 * Honorable Mentions
+:PROPERTIES:
+:CUSTOM_ID: honorable-mentions
+:END:
 
 https://github.com/mxhold/opted has similar aims to =monad-oxide= - essentially
 a Rust port of the =Result= type.
 
+* Roadmap
+:PROPERTIES:
+:CUSTOM_ID: roadmap
+:END:
+** Add Option
+:PROPERTIES:
+:CUSTOM_ID: roadmap--add-option
+:END:
+
+This would complete the Rust monads that I know of.  =Option= is Rust's answer
+to =nil=.
+
+*** Add Advanced Option Functionality
+:PROPERTIES:
+:CUSTOM_ID: roadmap--add-option--add-advanced-option-functionality
+:END:
+
+This covers methods needed on =Array=, and translation methods between =Result=
+and =Option=, as well as boolean operations.  This can all be done as separate
+work from general =Option= support as well as separate from each other.
+
+If we did =<<= and =>>= for =Result=, we should repeat that for =Option= as
+well.
+
+** Check on Documentation Generation
+:PROPERTIES:
+:CUSTOM_ID: roadmap--check-on-documentation-generation
+:END:
+
+We can run =yard= documentation generation locally but I don't think we can push
+it to the official docs site (I don't have a link handy, and am offline).  That
+said, I have seen generated documentation.  I have a ticket open for this, and
+should see if it needs to be closed.  I don't have the link handy either.
+
+** Support boolean operators
+:PROPERTIES:
+:CUSTOM_ID: roadmap--support-boolean-operators
+:END:
+
+=or=, =and=, etc should be supported.  In addition, we can support =||= and =&&=
+and maybe some others that Ruby allows.
+
+** Support bind operator for Result?
+:PROPERTIES:
+:CUSTOM_ID: roadmap--support-bind-operator-for-result
+:END:
+
+We could override =<<= and =>>= to mean =and_then= and =or_else=.  I'd have to
+see what that looks like.  Granted this isn't in the Rust capabilities, but it
+might be fitting for Ruby.  Those who don't want the syntax are not compelled to
+use it.
+
+** Support =?= equivalent
+:PROPERTIES:
+:CUSTOM_ID: roadmap--support-==-equivalent
+:END:
+
+I don't know that this is reasonably doable in Ruby, but I admit it's handy in
+Rust.  Being able to handle the unwrap-or-return-err-early behavior would be
+nice even if it didn't look as pretty as =?=.  We could allow decoration on a
+method (=monad_oxide(:method)=) which rescues a special, internal =Exception=.
+I think with actual Ruby exception handling this could be easy to mess up.
+Perhaps we could do some meta programming where we force the early return via
+binding?
+
+In any case, some equivalent to this could be nice.
+** Additional Feature Parity
+:PROPERTIES:
+:CUSTOM_ID: roadmap--additional-feature-parity
+:END:
+
+We should strive to stay in feature parity with Rust's =Option= and =Result= but
+I don't have an exhaustive list right now.  Currently it's very nearly complete.
+It would be helpful to have a tally and a documented percentage of parity.
+
 * COMMENT Quirks in Documentation
+:PROPERTIES:
+:CUSTOM_ID: quirks-in-documentation
+:END:
 
 I can't make repeating =:header-args:= to split up the lines, despite there
 seeming to be _some_ examples indicating otherwise.

--- a/lib/err.rb
+++ b/lib/err.rb
@@ -189,6 +189,16 @@ module MonadOxide
     end
 
     ##
+    # Safely unwrap the `Result`.  In the case of `Err`, this returns the
+    # wrapped value.
+    #
+    # @param _f A dummy function.  Not used.
+    # @return [T] The wrapped value.
+    def unwrap_err_or_else(f=nil, &_block)
+      @data
+    end
+
+    ##
     # Safely unwrap the `Result`. In the case of `Err`, this returns the
     # provided default value.
     #
@@ -196,6 +206,19 @@ module MonadOxide
     # @return [T] The `x` value.
     def unwrap_or(x)
       x
+    end
+
+    ##
+    # Safely unwrap the `Result`. In the case of `Err`, this uses the provided
+    # function to produce a value.
+    #
+    # @param f [Proc<B>] The function to call. Could be a block
+    #          instead.  Takes nothing and returns a [B=Object].
+    # @yield Will yield a block that takes nothing and returns a [B=Object].
+    #        Same as `f' parameter.
+    # @return [B] The value returned from `f`.
+    def unwrap_or_else(f=nil, &block)
+      (f || block).call()
     end
 
   end

--- a/lib/err_spec.rb
+++ b/lib/err_spec.rb
@@ -449,10 +449,44 @@ describe MonadOxide::Err do
     end
   end
 
+  context '#unwrap_err_or_else' do
+
+    context 'with Blocks' do
+      it 'returns the wrapped data' do
+        expect(MonadOxide.err('foo').unwrap_err_or_else {|| 'bar'}).to(eq('foo'))
+      end
+    end
+
+    context 'with Procs' do
+      it 'returns the wrapped data' do
+        expect(
+          MonadOxide.err('foo').unwrap_err_or_else(->() {'bar'}),
+        ).to(eq('foo'))
+      end
+    end
+
+  end
+
   context '#unwrap_or' do
 
     it 'returns the passed data' do
       expect(MonadOxide.err('foo').unwrap_or('bar')).to(eq('bar'))
+    end
+
+  end
+
+  context '#unwrap_or_else' do
+
+    context 'with Blocks' do
+      it 'returns the data from the passed block' do
+        expect(MonadOxide.err('foo').unwrap_or_else() {|| 'bar'}).to(eq('bar'))
+      end
+    end
+
+    context 'with Procs' do
+      it 'returns the data from the passed function' do
+        expect(MonadOxide.err('foo').unwrap_or_else(->() {'bar'})).to(eq('bar'))
+      end
     end
 
   end

--- a/lib/ok.rb
+++ b/lib/ok.rb
@@ -147,12 +147,36 @@ module MonadOxide
     end
 
     ##
+    # Safely unwrap the `Result`.  In the case of `Ok`, this uses the provided
+    # function to produce a value.
+    #
+    # @param f [Proc<B>] The function to call. Could be a block
+    #          instead.  Takes nothing and returns a [B=Object].
+    # @yield Will yield a block that takes nothing and returns a [B=Object].
+    #        Same as `f' parameter.
+    # @return [B] The value returned from `f`.
+    def unwrap_err_or_else(f=nil, &block)
+      (f || block).call()
+    end
+
+    ##
     # Safely unwrap the `Result`. In the case of `Ok`, this returns the
     # data in the Ok.
     #
-    # @param [B] x The value that will be returned.
+    # @param [B] _x The value that will be returned.
     # @return [A] The data in the Ok.
-    def unwrap_or(_)
+    def unwrap_or(_x)
+      @data
+    end
+
+    ##
+    # Safely unwrap the `Result`.  In the case of `Ok`, this returns the
+    # wrapped value.
+    #
+    # @param f [Proc<B>] A dummy function.  Not used.
+    #          instead.  Takes nothing and returns a [B=Object].
+    # @return [B] The value returned from `f`.
+    def unwrap_or_else(_f=nil, &_block)
       @data
     end
 

--- a/lib/ok_spec.rb
+++ b/lib/ok_spec.rb
@@ -417,10 +417,44 @@ describe MonadOxide::Ok do
     end
   end
 
+  context '#unwrap_err_or_else' do
+
+    context 'with Blocks' do
+      it 'returns the data from the passed block' do
+        expect(MonadOxide.ok('foo').unwrap_err_or_else {|| 'bar'}).to(eq('bar'))
+      end
+    end
+
+    context 'with Procs' do
+      it 'returns the data from the passed function' do
+        expect(
+          MonadOxide.ok('foo').unwrap_err_or_else(->() {'bar'}),
+        ).to(eq('bar'))
+      end
+    end
+
+  end
+
   context '#unwrap_or' do
 
     it 'returns the data from the Ok' do
       expect(MonadOxide.ok('foo').unwrap_or('bar')).to(eq('foo'))
+    end
+
+  end
+
+  context '#unwrap_or_else' do
+
+    context 'with Blocks' do
+      it 'returns the wrapped data' do
+        expect(MonadOxide.ok('foo').unwrap_or_else() {|| 'bar'}).to(eq('foo'))
+      end
+    end
+
+    context 'with Procs' do
+      it 'returns the wrapped data' do
+        expect(MonadOxide.ok('foo').unwrap_or_else(->() {'bar'})).to(eq('foo'))
+      end
     end
 
   end

--- a/lib/result.rb
+++ b/lib/result.rb
@@ -241,6 +241,21 @@ module MonadOxide
     end
 
     ##
+    # Safely unwrap the `Result` but with lazy evaluation.  In the case of
+    # `Err`, this returns the wrapped value.  For `Ok` the function provided is
+    # evaluated and its returned value is what is returned.
+    #
+    # @param f [Proc<B>] The function to call for `Ok`. Could be a block
+    #          instead.  Takes nothing and returns a [B=Object].
+    # @yield Will yield a block for `Ok` that takes nothing and returns a
+    #        [B=Object].  Same as `f' parameter.
+    # @return [T|B] The wrapped value for `Err` and the returned from `f` for
+    #               `Ok`.
+    def unwrap_err_or_else(_f)
+      raise ResultMethodNotImplementedError.new()
+    end
+
+    ##
     # Attempt to safely access the `Result` data. This always returns a value
     # instead of raising an Exception. In the case of `Ok`, the data is
     # returned. In the case of `Err`, the value provided is returned.
@@ -248,6 +263,36 @@ module MonadOxide
     # @return [T|B] The inner data of this `Ok` or the passee value.
     def unwrap_or(_)
       Err.new(ResultMethodNotImplementedError.new())
+    end
+
+    ##
+    # Safely unwrap the `Result` but with lazy evaluation.  In the case of
+    # `Ok`, this returns the wrapped value.  For `Err` the function provided is
+    # evaluated and its returned value is what is returned.
+    #
+    # @param f [Proc<B>] The function to call for `Err`. Could be a block
+    #          instead.  Takes nothing and returns a [B=Object].
+    # @yield Will yield a block for `Err` that takes nothing and returns a
+    #        [B=Object].  Same as `f' parameter.
+    # @return [T|B] The wrapped value for `Ok` and the returned from `f` for
+    #               `Err`.
+    def unwrap_or_else(_f)
+      raise ResultMethodNotImplementedError.new()
+    end
+
+    ##
+    # Safely unwrap the `Result` but with lazy evaluation.  In the case of `Ok`,
+    # this returns the wrapped value.  For `Err` the function provided is
+    # evaluated and its returned value is what is returned.
+    #
+    # @param f [Proc<B>] The function to call for `Err`. Could be a block
+    #          instead.  Takes nothing and returns a [B=Object].
+    # @yield Will yield a block for `Err` that takes nothing and returns a
+    #        [B=Object].  Same as `f' parameter.
+    # @return [T|B] The wrapped value for `Ok` and the returned from `f` for
+    #               `Err`.
+    def unwrap_or_else(_f)
+      raise ResultMethodNotImplementedError.new()
     end
 
   end


### PR DESCRIPTION
This adds `MonadOxide::Result#unwrap_or_else` and `MonadOxide::Result#unwrap_err_or_else`.  These allow performing safe unwraps with functions instead of hardcoded values.

Earmarked as these additional changes:
1. Add custom properties (for consistent navigation) in the README, and document the roadmap of this library.
2. Ignore Yard generated metadata.