### PR TITLE
retroactively add notes to changelog

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -11,6 +11,8 @@
 *** Breaking
 *** Additions
 *** Fixes
+1. Retroactively add some release notes.  Not comprehensive.
+2. Correct typo in code comments.
 ** v0.11.0
 *** Breaking
 *** Additions
@@ -20,18 +22,24 @@
 ** v0.10.0
 *** Breaking
 *** Additions
+1. Add ~Result#unwrap_or_else~ and ~Result#unwrap_err_or_else~ for providing
+   safe yet dynamic unwraps of ~Result~.
 *** Fixes
 ** v0.9.0
 *** Breaking
 *** Additions
+1. Add ~Result#ok?~ and ~Result#err?~ to make a smooth ~rspec~ experience using
+   its BDD style.
 *** Fixes
 ** v0.8.0
 *** Breaking
 *** Additions
 *** Fixes
+1. Fix method reference in README.
 ** v0.7.0
 *** Breaking
 *** Additions
+1. Add ~unwrap_or~ to ~Result~ for safely unwrapping ~Err~.
 *** Fixes
 ** v0.6.0
 *** Breaking

--- a/release.rb
+++ b/release.rb
@@ -5,7 +5,7 @@ require_relative './version'
 version = "0.#{version_get().to_i + 1}.0"
 puts "Creating and pushing tag '#{version}'."
 version_set(version)
-# --no-deployment allows the Gemfile.lock to update. This isn't technical a
+# --no-deployment allows the Gemfile.lock to update. This isn't technically a
 # deployment (such as like deploying a Rails app), so this isn't too egregious.
 puts `bundle config unset deployment && bundle install --no-deployment`
 # Gemfile.lock is also bumped after this, and needs to be added or it will foul


### PR DESCRIPTION
This adds some notes to the changelog.  I had these ready in case I needed multiple commits to fix the `main` release build, but it seems to work now so these aren't necessary.  The added notes are not exhaustive.