### PR TITLE
add Either

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -10,6 +10,9 @@
 ** Upcoming
 *** Breaking
 *** Additions
+1. Add ~Either~, a structure similar to ~Result~ but uses unbiased ~Left~ and
+   ~Right~ branches - meaning there is no assumption that one branch must be an
+   error.  It is not in total feature parity, but much of it is usable.
 *** Fixes
 ** v0.12.0
 *** Breaking

--- a/README.org
+++ b/README.org
@@ -35,6 +35,10 @@ functional error handling. In this library, =Either= is essentially the same as
 :CUSTOM_ID: examples
 :end:
 
+** Result
+:PROPERTIES:
+:CUSTOM_ID: examples--result
+:END:
 Example Disclaimer:
 
 Despite lots of these examples using =unwrap= and =unwrap_err=, these are highly
@@ -46,9 +50,9 @@ production instances. If so, code defensively around their usages and try to use
 the methods sparingly.  Having a dedicated quarantine zone around your =unwrap=
 and =unwrap_err= is the most preferable.
 
-** map
+*** map
 :PROPERTIES:
-:CUSTOM_ID: examples--map
+:CUSTOM_ID: examples--result--map
 :END:
 
 Changing the inner value with =map=:
@@ -57,7 +61,7 @@ require 'monad-oxide'
 
 MonadOxide.ok('test')
   .map(->(s) { s.upcase() })
-  .unwrap() # 'test'
+  .unwrap() # 'TEST'
 #+end_src
 
 #+RESULTS:
@@ -81,9 +85,9 @@ MonadOxide.ok('test')
 #+RESULTS:
 : #<ArgumentError: Can't have 'e' in test data.>
 
-** inspect
+*** inspect
 :PROPERTIES:
-:CUSTOM_ID: examples--inspect
+:CUSTOM_ID: examples--result--inspect
 :END:
 
 Inspecting a value in the chain without changing it:
@@ -107,9 +111,9 @@ MonadOxide.ok('test')
 
 #+RESULTS:
 : #<ArgumentError: Can't have 'e' in test data.>
-** =<kind>?= checks
+*** =<kind>?= checks
 :PROPERTIES:
-:CUSTOM_ID: examples--=<kind>=-checks
+:CUSTOM_ID: examples--result--=<kind>=-checks
 :END:
 
 You can check to see if you're working with an =Ok= or =Err= with =ok?= and
@@ -151,9 +155,9 @@ MonadOxide.err('foo').err?()
 #+RESULTS:
 : true
 
-*** with =rspec=
+**** with =rspec=
 :PROPERTIES:
-:CUSTOM_ID: examples--=<kind>=-checks--with-=rspec=
+:CUSTOM_ID: examples--result--=<kind>=-checks--with-=rspec=
 :END:
 
 And with =rspec=.  There's some difficulty in finding the right incantation to
@@ -169,9 +173,9 @@ expect(MonadOxide.err('foo')).to(be_err) # Pass.
 #+end_src
 
 
-** unwrapping
+*** unwrapping
 :PROPERTIES:
-:CUSTOM_ID: examples--unwrapping
+:CUSTOM_ID: examples--result--unwrapping
 :END:
 
 Unwrapping is the act of accessing the value inside the =Result=. It is often
@@ -179,9 +183,9 @@ considered dangerous because it raises exceptions - an action counter to the
 whole purpose of =monad-oxide=. However, there are variants documented below to
 make the operation safe.
 
-*** unwrap and unwrap_err
+**** unwrap and unwrap_err
 :PROPERTIES:
-:CUSTOM_ID: examples--unwrapping--unwrap-and-unwrap_err
+:CUSTOM_ID: examples--result--unwrapping--unwrap-and-unwrap_err
 :END:
 
 =unwrap= and =unwrap_err= both access inner =Ok= and =Err= data, respectively.
@@ -243,9 +247,9 @@ MonadOxide.err('foo').unwrap_err()
 #+RESULTS:
 : foo
 
-*** unwrap_or
+**** unwrap_or
 :PROPERTIES:
-:CUSTOM_ID: examples--unwrapping--unwrap_or
+:CUSTOM_ID: examples--result--unwrapping--unwrap_or
 :END:
 
 =unwrap_or= provides a safe means of unwrapping via a fallback value that is
@@ -273,9 +277,9 @@ MonadOxide.err('foo').unwrap_or('bar')
 #+RESULTS:
 : bar
 
-*** unwrap_or_else and unwrap_err_or_else
+**** unwrap_or_else and unwrap_err_or_else
 :PROPERTIES:
-:CUSTOM_ID: examples--unwrapping--unwrap_or_else-and-unwrap_err_or_else
+:CUSTOM_ID: examples--result--unwrapping--unwrap_or_else-and-unwrap_err_or_else
 :END:
 
 =unwrap_or_else= and =unwrap_err_or_else= both access inner =Ok= and =Err= data,
@@ -329,9 +333,9 @@ MonadOxide.err('foo').unwrap_err(->() { 'bar' })
 #+RESULTS:
 : foo
 
-** arrays
+*** arrays
 :PROPERTIES:
-:CUSTOM_ID: examples--arrays
+:CUSTOM_ID: examples--result--arrays
 :END:
 
 You can use =#into_result= to convert an =Array= of =Results= to =Result= of an
@@ -370,9 +374,9 @@ require 'monad-oxide'
 #+RESULTS:
 : ["bar", "qux"]
 
-** complex operations
+*** complex operations
 :PROPERTIES:
-:CUSTOM_ID: examples--complex-operations
+:CUSTOM_ID: examples--result--complex-operations
 :END:
 
 Complex operation:
@@ -407,6 +411,102 @@ MonadOxide.ok('test')
   .unwrap_err() # The above AppError containing an ArgumentError.
 #+end_src
 
+** Either
+:PROPERTIES:
+:CUSTOM_ID: examples--either
+:END:
+
+~Either~ represents a dual state where neither branch is given a bias (such as
+~Result~'s ~Ok~ and ~Err~ representing success and error branches).  ~Either~
+uses the arbitrary ~Left~ and ~Right~.
+
+This type ultimately is inspired by [[https://hackage.haskell.org/package/base-4.21.0.0/docs/Data-Either.html][Haskell's Either]], which uses ~Left~ for
+non-preferable branches and ~Right~ for preferable branches ("Right" being a
+synonym for "correct").
+
+One use case is to tally up results of some computation, where some of the
+results are non-fatal errors that should be ignored for future calculations.  In
+such a case you would produce ~Lefts~ for the errors (or maybe even skips) and
+~Rights~ for data that can move forward to the next steps.
+
+*** mapping
+:PROPERTIES:
+:CUSTOM_ID: examples--either--mapping
+:END:
+
+Changing the inner value with ~map_<direction>~:
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.left('test')
+  .map_left(->(s) { s.upcase() })
+  .unwrap_left() # 'TEST'
+#+end_src
+
+#+RESULTS:
+: TEST
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.right('test')
+  .map_right(->(s) { s.upcase() })
+  .unwrap_right() # 'TEST'
+#+end_src
+
+#+RESULTS:
+: TEST
+
+But note how changes don't happen when the sides are mismatched:
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.left('test')
+  .map_right(->(s) { s.upcase() })
+  .unwrap_left() # 'test'
+#+end_src
+
+#+RESULTS:
+: test
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.right('test')
+  .map_left(->(s) { s.upcase() })
+  .unwrap_right() # 'test'
+#+end_src
+
+#+RESULTS:
+: test
+
+*** monadic and_then
+:PROPERTIES:
+:CUSTOM_ID: examples--either--monadic-and_then
+:END:
+
+Note how ~Either#unwrap_right~ must be used:
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.left('test')
+  .left_and_then(->(s) { Either.right(s.upcase()) })
+  .unwrap_right() # 'TEST'
+#+end_src
+
+And the reverse:
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.right('test')
+  .right_and_then(->(s) { Either.Left(s.upcase()) })
+  .unwrap_left() # 'TEST'
+#+end_src
+
 * Honorable Mentions
 :PROPERTIES:
 :CUSTOM_ID: honorable-mentions
@@ -438,6 +538,32 @@ work from general =Option= support as well as separate from each other.
 
 If we did =<<= and =>>= for =Result=, we should repeat that for =Option= as
 well.
+
+** Add Examples for All Either Operations
+:PROPERTIES:
+:CUSTOM_ID: roadmap--add-examples-for-all-either-operations
+:END:
+
+Result operations:
++ [X] ~map~
++ [X] ~and_then~
++ [ ] ~or_else~
++ [ ] ~unwrap~ et. al.
++ [ ] ~inspect~
++ [ ] ~rspec~ with ~be_left~ and ~be_right~.
+
+** Add Examples for All Result Operations
+:PROPERTIES:
+:CUSTOM_ID: roadmap--add-examples-for-all-result-operations
+:END:
+
+Result operations:
++ [X] ~map~
++ [ ] ~and_then~
++ [ ] ~or_else~
++ [X] ~unwrap~ et. al.
++ [X] ~inspect~
++ [ ] ~rspec~ with ~be_ok~ and ~be_err~.
 
 ** Check on Documentation Generation
 :PROPERTIES:

--- a/lib/either.rb
+++ b/lib/either.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+################################################################################
+# Provide an Either type (either one thing or another thing).  Either represents
+# this with a Left or a Right.  The notable difference is Either doesn't assume
+# one of the branches must be some kind of error - in fact no branch of Either
+# has any preference to Left or Right.
+#
+# This is not part of Rust's standard library but it fits well with the monadic
+# operations that Rust has with Result and Option.  This particular
+# implementation is a port from the Either library for Rust
+# (https://docs.rs/either/latest/either/enum.Either.html).
+#
+# Be mindful that an Either can raise exceptions if errors are present in its
+# calls.  Since Either is not strictly compatible with Result, we cannot safely
+# convert some operation to a Result implicitly.
+################################################################################
+
+require_relative './error'
+
+module MonadOxide
+
+  ##
+  # Thie Exception signals an area under construction, or somehow the consumer
+  # wound up with a `Result' and not one of its subclasses (@see Ok and @see
+  # Err). Implementors of new methods on `Ok' and `Err' should create methods on
+  # `Result' as well which immediately raise this `Exception'.
+  class EitherMethodNotImplementedError < MonadOxideError; end
+
+  ##
+  # This `Exception' is produced when a method that expects the function or
+  # block to provide a `Result' but was given something else. Generally this
+  # Exception is not raised, but instead converts the Result into a an Err.
+  # Example methods with this behavior are Result#and_then and Result#or_else.
+  class EitherReturnExpectedError < MonadOxideError
+    ##
+    # The transformation expected a `Result' but got something else.
+    # @param data [Object] Whatever we got that wasn't a `Result'.
+    def initialize(data)
+      super("An Either was expected but got #{data.inspect()}.")
+      data = @data
+    end
+    attr_reader(:data)
+  end
+
+  class Either
+
+    def initialize(_data)
+      raise NoMethodError.new('Do not use Either directly. See Left and Right.')
+    end
+
+    ##
+    # Use pattern matching to work with both Left and Right variants. This is
+    # useful when it is desirable to have both variants handled in the same
+    # location.  It can also be useful when either variant can coerced into a
+    # non-Result type.
+    #
+    # Ruby has no built-in pattern matching, but the next best thing is a Hash
+    # using the Either classes themselves as the keys.
+    #
+    # Tests for this are found in the tests of the Left and Right classes.
+    #
+    # @param matcher [Hash<Class, Proc<T | E, R>] matcher The matcher to match
+    # upon.
+    # @option matcher [Proc] MonadOxide::Left The branch to execute for Left.
+    # @option matcher [Proc] MonadOxide::Right The branch to execute for Right.
+    # @return [R] The return value of the executed Proc.
+    def match(matcher)
+      matcher[self.class()].call(@data)
+    end
+
+  end
+
+end

--- a/lib/error.rb
+++ b/lib/error.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+################################################################################
+# Houses generic exception types.
+#
+# Not to be mistaken with err.rb for MonadOxide::Err.
+################################################################################
+module MonadOxide
+
+  ##
+  # All errors in monad-oxide should inherit from this error. This makes it easy
+  # to handle library-wide errors on the consumer side.
+  class MonadOxideError < StandardError; end
+
+  ##
+  # This `Exception' is raised when the consumer makes a dangerous wager
+  # about which state the `Result' is in, and lost. More specifically: An `Ok'
+  # cannot unwrap an Exception, and an `Err' cannot unwrap the `Ok' data.
+  class UnwrapError < MonadOxideError; end
+
+end

--- a/lib/left.rb
+++ b/lib/left.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+################################################################################
+#
+################################################################################
+
+require_relative './error'
+
+module MonadOxide
+
+  ##
+  # `Left' represents an arbitrary branch of Either.  Since Either is supposed
+  # to be unbiased, you can assign any bias you like to Left, though in some
+  # ecosystems (such as Haskell, where this Either is ultimately inspired from),
+  # the Left side is the less common/favorable one, but this is only out of
+  # convention.
+  class Left < Either
+
+    ##
+    # Constructs a `Left' with the data provided.
+    # @param data [Object] The inner data this Either encapsulates.
+    def initialize(data)
+      @data = data
+    end
+
+    ##
+    # Applies `f` or the block over the data and returns the same `Left`.  No
+    # changes are applied.  This is ideal for logging.  @see Either#inspect_left
+    # for a higher level understanding how this works with Eithers in general.
+    # @param f [Proc<A, _>] The function to call. Could be a block instead.
+    #          Takes an `A` the return is ignored.
+    # @yield Will yield a block that takes an A the return is ignored.  Same as
+    #        `f' parameter.
+    # @return [Either<A, B>] returns self.
+    def inspect_left(f=nil, &block)
+      (f || block).call(@data)
+      self
+    end
+
+    ##
+    # Falls through. @see Either#inspect_right for how this is handled in the
+    # Either case, and @see Right#inspect_right for how this is handled in the
+    # Right case.
+    # @param f [Proc] Optional Proc - ignored.
+    # @yield An ignored block.
+    # @return [Either] This Either.
+    def inspect_right(f=nil, &block)
+      self
+    end
+
+    ##
+    # Identifies that this is a `Left`.
+    # For counterparts:
+    # @see MonadOxide::Left#right?
+    # @see MonadOxide::Right#left?
+    # @see MonadOxide::Right#right?
+    # @return [Boolean] `true` because this is a `Left`.
+    def left?()
+      true
+    end
+
+    ##
+    # Invokes `f' or the block with the data and returns the Either returned
+    # from that.  The return type is enforced.
+    # @param f [Proc<A, Result<C>>] The function to call. Could be a block
+    #          instead. Takes an [A=Object] and must return a [Either<C, B>].
+    # @yield Will yield a block that takes an A and returns a Either<C>. Same as
+    #        `f' parameter.
+    # @return [Left<C> | Right<C>] A new Result from `f' or the
+    #         block.  If the return value is a non-Either, this this will raise
+    #         `EitherReturnExpectedError'.
+    def left_and_then(f=nil, &block)
+      either = (f || block).call(@data)
+      if either.is_a?(Either)
+        either
+      else
+        raise EitherReturnExpectedError.new(either)
+      end
+    end
+
+
+    ##
+    # Applies `f' or the block over the data and returns a new `Left' with the
+    # returned value.
+    # @param f [Proc<A, C>] The function to call. Could be a block
+    #          instead. Takes an [A=Object] and returns a C.
+    # @yield Will yield a block that takes an A and returns a C. Same as
+    #        `f' parameter.
+    # @return [Either<C, B>] A new `Left<C>' whose `C' is the return of `f' or
+    #         the block.
+    def map_left(f=nil, &block)
+      Left.new((f || block).call(@data))
+    end
+
+    ##
+    # This is a no-op for Left. @see Right#map_right.
+    # @param f [Proc<A, C>] A dummy function. Not used.
+    # @yield A dummy block. Not used.
+    # @return [Either<A, B>] This `Left'.
+    def map_right(f=nil, &block)
+      self
+    end
+
+    ##
+    # Identifies that this is not a `Right`.
+    # For counterparts:
+    # @see MonadOxide::Left#left?
+    # @see MonadOxide::Right#left?
+    # @see MonadOxide::Right#right?
+    # @return [Boolean] `false` because this is not a `Right`.
+    def right?()
+      false
+    end
+
+    ##
+    # The Left equivalent to Right#left_and_then.  This is a no-op for Left.
+    # @see Right#right_and_then.
+    # @param f [Proc<A, B>] A dummy function. Not used.
+    # @yield A dummy block. Not used.
+    # @return [Either<A, B>] This `Either'.
+    def right_and_then(f=nil, &block)
+      self
+    end
+
+    ##
+    # Dangerously access the `Left' data.  If this is a `Right', an
+    # `UnwrapError` will be raised.  It is recommended to use this for tests
+    # only.
+    # @return [A] The inner data of this `Left'.
+    def unwrap_left()
+      @data
+    end
+
+    ##
+    # Dangerously access the `Right' data.  Since this is a `Left', it will
+    # always raise an error.  @see Either#unwrap_right.  It is recommended to
+    # use this for tests only.
+    # @return [E] The data of this `Right'.
+    def unwrap_right()
+      raise UnwrapError.new(
+        <<~EOE
+          #{self.class()} with #{@data.inspect()} could not be unwrapped as a
+          Right.
+        EOE
+      )
+    end
+
+  end
+
+end

--- a/lib/left_spec.rb
+++ b/lib/left_spec.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require 'monad-oxide'
+
+describe MonadOxide::Left do
+
+  context '#left_and_then' do
+
+    context 'with blocks' do
+
+      it 'passes the data from the Left to the block' do
+        expect(
+          MonadOxide.left('foo')
+            .left_and_then() { |s| MonadOxide.left(s + 'bar') }
+            .unwrap_left()
+        ).to(eq('foobar'))
+      end
+
+      it 'raises an error if the block returns a non-Either' do
+        expect() {
+          MonadOxide.left('foo')
+            .left_and_then() {|_| 'bar' }
+            .unwrap_left()
+        }.to(raise_error(MonadOxide::EitherReturnExpectedError))
+      end
+
+      it 'returns the same Left returned by the block' do
+        expect(
+          MonadOxide.left('foo')
+            .left_and_then() {|_| MonadOxide.left('bar') }
+            .unwrap_left()
+        ).to(eq('bar'))
+      end
+
+      it 'returns the same Right returned by the block' do
+        expect(
+          MonadOxide.left('foo')
+            .left_and_then() {|_| MonadOxide.right('bar') }
+            .unwrap_right()
+        ).to(eq('bar'))
+      end
+
+    end
+
+    context 'with Procs' do
+
+      it 'passes the data from the Left to the Proc' do
+        expect(
+          MonadOxide.left('foo')
+            .left_and_then(->(s) { MonadOxide.left(s + 'bar') })
+            .unwrap_left()
+        ).to(eq('foobar'))
+      end
+
+      it 'raises an error if the Proc returns a non-Either' do
+        expect() {
+          MonadOxide.left('foo')
+            .left_and_then(->(_) { 'bar' })
+            .unwrap_left()
+        }.to(raise_error(MonadOxide::EitherReturnExpectedError))
+      end
+
+      it 'returns the same Left returned by the Proc' do
+        expect(
+          MonadOxide.left('foo')
+            .left_and_then(->(_) { MonadOxide.left('bar') })
+            .unwrap_left()
+        ).to(eq('bar'))
+      end
+
+      it 'returns the same Right returned by the Proc' do
+        expect(
+          MonadOxide.left('foo')
+            .left_and_then(->(_) { MonadOxide.right('bar') })
+            .unwrap_right()
+        ).to(eq('bar'))
+      end
+
+    end
+
+    context '#left?' do
+      it 'is a Left' do
+        expect(MonadOxide.left('foo')).to(be_left())
+      end
+    end
+
+    context '#right?' do
+      it 'is not a Right' do
+        expect(MonadOxide.left('foo')).not_to(be_right())
+      end
+    end
+
+    context('#inspect_left') {
+
+      context('with a Proc') {
+
+        it('applies the data to the Proc provided') {
+          effected = 'unset'
+          MonadOxide
+            .left('foo')
+            .inspect_left(->(s) { effected = "effect: #{s}" })
+          expect(effected).to(eq('effect: foo'))
+        }
+
+        it('does not change the underlying data') {
+          expect(
+            MonadOxide
+              .left('foo')
+              .inspect_left(->(_) { 'bar' })
+              .unwrap_left()
+          ).to(eq('foo'))
+        }
+
+      }
+
+      context('with a block') {
+
+        it('applies the data to the Proc provided') {
+          effected = 'unset'
+          MonadOxide.left('foo')
+            .inspect_left() { |s| effected = "effect: #{s}" }
+          expect(effected).to(eq('effect: foo'))
+        }
+
+        it('does not change the underlying data') {
+          expect(
+            MonadOxide
+              .left('foo')
+              .inspect_left() { |_| 'bar' }
+              .unwrap_left()
+          ).to(eq('foo'))
+        }
+
+      }
+
+    }
+
+    context('#inspect_right') {
+
+      context('with a Proc') {
+
+        it('does not execute the function provided') {
+          effect = 'unset'
+          expect(
+            MonadOxide
+              .left('foo')
+              .inspect_right(->(_) { effect = 'bar' })
+              .unwrap_left()
+          ).to(eq('foo'))
+        }
+
+        it('does not execute the function provided') {
+          effect = 'unset'
+          MonadOxide
+            .left('foo')
+            .inspect_right(->(_) { effect = 'bar' })
+          expect(effect).to(eq('unset'))
+        }
+
+      }
+
+      context('with a block') {
+
+        it('returns the Left with the original value') {
+          expect(
+            MonadOxide
+              .left('foo')
+              .inspect_right() { |_| 'bar' }
+              .unwrap_left()
+          ).to(eq('foo'))
+        }
+
+        it('does not execute the function provided') {
+          effect = 'unset'
+          MonadOxide
+            .left('foo')
+            .inspect_right() { |_| effect = 'bar' }
+          expect(effect).to(eq('unset'))
+        }
+
+      }
+
+    }
+
+    context('#right_and_then') {
+
+      context('with a Proc') {
+
+        it('does not execute the function provided') {
+          expect(
+            MonadOxide
+              .left('foo')
+              .right_and_then(->(_) { 'bar' })
+              .unwrap_left()
+          ).to(eq('foo'))
+        }
+
+      }
+
+      context('with a block') {
+
+        it('does not execute the function provided') {
+          expect(
+            MonadOxide
+              .left('foo')
+              .right_and_then() { 'bar' }
+              .unwrap_left()
+          ).to(eq('foo'))
+        }
+
+      }
+
+    }
+
+  end
+
+  context '#match' do
+
+    it 'returns the Left branch proc\'s value' do
+      expect(
+        MonadOxide
+          .left('foo')
+          .match({
+            MonadOxide::Left => ->(_x) { 'bar' },
+            MonadOxide::Right => ->(_x) { 'error' },
+          })
+      ).to(eq('bar'))
+    end
+
+    it 'operates on the Left\'s value' do
+      expect(
+        MonadOxide
+          .left('foo')
+          .match({
+            MonadOxide::Left => ->(x) { "#{x}bar" },
+            MonadOxide::Right => ->(_x) { 'error' },
+          })
+      ).to(eq('foobar'))
+    end
+
+  end
+
+end

--- a/lib/monad-oxide.rb
+++ b/lib/monad-oxide.rb
@@ -1,6 +1,9 @@
 require_relative './result'
 require_relative './err'
 require_relative './ok'
+require_relative './either'
+require_relative './left'
+require_relative './right'
 require_relative './array'
 require_relative './version'
 
@@ -18,6 +21,10 @@ module MonadOxide
     MonadOxide::Err.new(data)
   end
 
+  def left(data)
+    MonadOxide::Left.new(data)
+  end
+
   ##
   # Create an `Ok' as a conveniece method.
   # @param data [Object] The inner data for this `Ok'.
@@ -25,4 +32,9 @@ module MonadOxide
   def ok(data)
     MonadOxide::Ok.new(data)
   end
+
+  def right(data)
+    MonadOxide::Right.new(data)
+  end
+
 end

--- a/lib/ok.rb
+++ b/lib/ok.rb
@@ -1,4 +1,5 @@
 require_relative './result'
+require_relative './error'
 
 module MonadOxide
   ##
@@ -53,7 +54,7 @@ module MonadOxide
 
     ##
     # Falls through. @see Result#inspect_err for how this is handled in either
-    # Result case, and @see Err.inspect_err for how this is handled in the Err
+    # Result case, and @see Err#inspect_err for how this is handled in the Err
     # case.
     # @param f [Proc] Optional Proc - ignored.
     # @yield An ignored block.
@@ -81,7 +82,7 @@ module MonadOxide
     end
 
     ##
-    # Applies `f' or the block over the data and returns a new new `Ok' with the
+    # Applies `f' or the block over the data and returns a new `Ok' with the
     # returned value.
     # @param f [Proc<A, B>] The function to call. Could be a block
     #          instead. Takes an [A=Object] and returns a B.

--- a/lib/result.rb
+++ b/lib/result.rb
@@ -1,8 +1,20 @@
+# frozen_string_literal: true
+################################################################################
+# A monadic way of handling error based flow.
+# A Result is a semi-abstract class, whose implementors are Ok or Err.  Ok
+# carries some data and represents a success case.  Err carries an error and
+# represents a failure case.
+
+# Most methods on Result will follow a success or error "track".  This means an
+# Ok will execute all of the success methods, such as inspect_ok, map, and
+# and_then.  Err will execute error methods, such as inspect_err, map_err, and
+# or_else.  In cases where the method doesn't match the state of the Result
+# (Ok/Err), they return self, which also means they just fall through.
+################################################################################
+
+require_relative './error'
+
 module MonadOxide
-  ##
-  # All errors in monad-oxide should inherit from this error. This makes it easy
-  # to handle library-wide errors on the consumer side.
-  class MonadOxideError < StandardError; end
 
   ##
   # Thie Exception signals an area under construction, or somehow the consumer
@@ -26,12 +38,6 @@ module MonadOxide
     end
     attr_reader(:data)
   end
-
-  ##
-  # This `Exception' is raised when the consumer makes a dangerous wager
-  # about which state the `Result' is in, and lost. More specifically: An `Ok'
-  # cannot unwrap an Exception, and an `Err' cannot unwrap the `Ok' data.
-  class UnwrapError < MonadOxideError; end
 
   ##
   # A Result is a chainable series of sequential transformations. The Result

--- a/lib/right.rb
+++ b/lib/right.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+################################################################################
+#
+################################################################################
+
+require_relative './error'
+
+module MonadOxide
+
+  ##
+  # `Right' represents an arbitrary branch of Either.  Since Either is supposed
+  # to be unbiased, you can assign any bias you like to Right, though in some
+  # ecosystems (such as Haskell, where this Either is ultimately inspired from),
+  # the Right side is the more common/favorable one, but this is only out of
+  # convention.
+  class Right < Either
+
+    def initialize(data)
+      @data = data
+    end
+
+    ##
+    # Falls through. @see Either#inspect_left for how this is handled in the
+    # Either case, and @see Left#inspect_left for how this is handled in the
+    # Left case.
+    # @param f [Proc] Optional Proc - ignored.
+    # @yield An ignored block.
+    # @return [Either] This Either.
+    def inspect_left(f=nil, &block)
+      self
+    end
+
+    ##
+    # Applies `f` or the block over the data and returns the same `Right`.  No
+    # changes are applied.  This is ideal for logging.  @see
+    # Either#inspect_right for a higher level understanding how this works with
+    # Eithers in general.
+    # @param f [Proc<A, _>] The function to call. Could be a block instead.
+    #          Takes an `A` the return is ignored.
+    # @yield Will yield a block that takes an A the return is ignored.  Same as
+    #        `f' parameter.
+    # @return [Either<A, B>] returns self.
+    def inspect_right(f=nil, &block)
+      (f || block).call(@data)
+      self
+    end
+
+    ##
+    # Identifies that this is not a `Left`.
+    # For counterparts:
+    # @see MonadOxide::Left#left?
+    # @see MonadOxide::Left#right??
+    # @see MonadOxide::Right#right?
+    # @return [Boolean] `false` because this is not a `Left`.
+    def left?()
+      false
+    end
+
+    ##
+    # The Right equivalent to Left#right_and_then.  This is a no-op for Right.
+    # @see Lefft#right_and_then.
+    # @param f [Proc<A, B>] A dummy function. Not used.
+    # @yield A dummy block. Not used.
+    # @return [Either<A, B>] This `Either'.
+    def left_and_then(f=nil, &block)
+      self
+    end
+
+    ##
+    # This is a no-op for Right. @see Left#map_left.
+    # @param f [Proc<A, C>] A dummy function. Not used.
+    # @yield A dummy block. Not used.
+    # @return [Either<A, B>] This `Left'.
+    def map_left(f=nil, &block)
+      self
+    end
+
+    ##
+    # Applies `f' or the block over the data and returns a new `Right' with the
+    # returned value.
+    # @param f [Proc<A, C>] The function to call. Could be a block
+    #          instead. Takes an [A=Object] and returns a C.
+    # @yield Will yield a block that takes an A and returns a C. Same as
+    #        `f' parameter.
+    # @return [Either<A, C>] A new `Right<C>' whose `C' is the return of `f' or
+    #         the block.
+    def map_right(f=nil, &block)
+      Right.new((f || block).call(@data))
+    end
+
+    ##
+    # Identifies that this is a `Right`.
+    # For counterparts:
+    # @see MonadOxide::Left#left?
+    # @see MonadOxide::Left#right?
+    # @see MonadOxide::Right#left?
+    # @return [Boolean] `true` because this is a `Right`.
+    def right?()
+      true
+    end
+
+    ##
+    # Invokes `f' or the block with the data and returns the Either returned
+    # from that.  The return type is enforced.
+    # @param f [Proc<A, Result<C>>] The function to call. Could be a block
+    #          instead. Takes an [A=Object] and must return a [Either<C, B>].
+    # @yield Will yield a block that takes an A and returns a Either<C>. Same as
+    #        `f' parameter.
+    # @return [Left<C> | Right<C>] A new Result from `f' or the
+    #         block.  If the return value is a non-Either, this this will raise
+    #         `EitherReturnExpectedError'.
+    def right_and_then(f=nil, &block)
+      either = (f || block).call(@data)
+      if either.is_a?(Either)
+        either
+      else
+        raise EitherReturnExpectedError.new(either)
+      end
+    end
+
+    ##
+    # Dangerously access the `Left' data.  Since this is a `Right', it will
+    # always raise an error.  @see Either#unwrap_left.  It is recommended to use
+    # this for tests only.
+    # @return [A] The inner data of this `Right'.
+    def unwrap_left()
+      raise UnwrapError.new(
+        <<~EOE
+        #{self.class()} with #{@data.inspect()} could not be unwrapped as a
+        Left.
+        EOE
+      )
+    end
+
+    ##
+    # Dangerously access the `Right' data.  If this is a `Left', an
+    # `UnwrapError` will be raised.  It is recommended to use this for tests
+    # only.
+    # @return [A] The inner data of this `Right'.
+    def unwrap_right()
+      @data
+    end
+
+  end
+
+end

--- a/lib/right_spec.rb
+++ b/lib/right_spec.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require 'monad-oxide'
+
+describe MonadOxide::Right do
+
+  context '#right_and_then' do
+
+    context 'with blocks' do
+
+      it 'passes the data from the Right to the block' do
+        expect(
+          MonadOxide.right('foo')
+            .right_and_then() { |s| MonadOxide.right(s + 'bar') }
+            .unwrap_right()
+        ).to(eq('foobar'))
+      end
+
+      it 'raises an error if the block returns a non-Either' do
+        expect() {
+          MonadOxide.right('foo')
+            .right_and_then() {|_| 'bar' }
+            .unwrap_right()
+        }.to(raise_error(MonadOxide::EitherReturnExpectedError))
+      end
+
+      it 'returns the same Right returned by the block' do
+        expect(
+          MonadOxide.right('foo')
+            .right_and_then() {|_| MonadOxide.right('bar') }
+            .unwrap_right()
+        ).to(eq('bar'))
+      end
+
+      it 'returns the same Left returned by the block' do
+        expect(
+          MonadOxide.right('foo')
+            .right_and_then() {|_| MonadOxide.left('bar') }
+            .unwrap_left()
+        ).to(eq('bar'))
+      end
+
+    end
+
+    context 'with Procs' do
+
+      it 'passes the data from the Right to the Proc' do
+        expect(
+          MonadOxide.right('foo')
+            .right_and_then(->(s) { MonadOxide.right(s + 'bar') })
+            .unwrap_right()
+        ).to(eq('foobar'))
+      end
+
+      it 'raises an error if the Proc returns a non-Either' do
+        expect() {
+          MonadOxide.right('foo')
+            .right_and_then(->(_) { 'bar' })
+            .unwrap_right()
+        }.to(raise_error(MonadOxide::EitherReturnExpectedError))
+      end
+
+      it 'returns the same Right returned by the Proc' do
+        expect(
+          MonadOxide.right('foo')
+            .right_and_then(->(_) { MonadOxide.right('bar') })
+            .unwrap_right()
+        ).to(eq('bar'))
+      end
+
+      it 'returns the same Left returned by the Proc' do
+        expect(
+          MonadOxide.right('foo')
+            .right_and_then(->(_) { MonadOxide.left('bar') })
+            .unwrap_left()
+        ).to(eq('bar'))
+      end
+
+    end
+
+    context '#right?' do
+      it 'is a Right' do
+        expect(MonadOxide.right('foo')).to(be_right())
+      end
+    end
+
+    context '#left?' do
+      it 'is not a Left' do
+        expect(MonadOxide.right('foo')).not_to(be_left())
+      end
+    end
+
+    context('#inspect_right') {
+
+      context('with a Proc') {
+
+        it('applies the data to the Proc provided') {
+          effected = 'unset'
+          MonadOxide
+            .right('foo')
+            .inspect_right(->(s) { effected = "effect: #{s}" })
+          expect(effected).to(eq('effect: foo'))
+        }
+
+        it('does not change the underlying data') {
+          expect(
+            MonadOxide
+              .right('foo')
+              .inspect_right(->(_) { 'bar' })
+              .unwrap_right()
+          ).to(eq('foo'))
+        }
+
+      }
+
+      context('with a block') {
+
+        it('applies the data to the Proc provided') {
+          effected = 'unset'
+          MonadOxide.right('foo')
+            .inspect_right() { |s| effected = "effect: #{s}" }
+          expect(effected).to(eq('effect: foo'))
+        }
+
+        it('does not change the underlying data') {
+          expect(
+            MonadOxide
+              .right('foo')
+              .inspect_right() { |_| 'bar' }
+              .unwrap_right()
+          ).to(eq('foo'))
+        }
+
+      }
+
+    }
+
+    context('#inspect_left') {
+
+      context('with a Proc') {
+
+        it('does not execute the function provided') {
+          effect = 'unset'
+          expect(
+            MonadOxide
+              .right('foo')
+              .inspect_left(->(_) { effect = 'bar' })
+              .unwrap_right()
+          ).to(eq('foo'))
+        }
+
+        it('does not execute the function provided') {
+          effect = 'unset'
+          MonadOxide
+            .right('foo')
+            .inspect_left(->(_) { effect = 'bar' })
+          expect(effect).to(eq('unset'))
+        }
+
+      }
+
+      context('with a block') {
+
+        it('returns the Right with the original value') {
+          expect(
+            MonadOxide
+              .right('foo')
+              .inspect_left() { |_| 'bar' }
+              .unwrap_right()
+          ).to(eq('foo'))
+        }
+
+        it('does not execute the function provided') {
+          effect = 'unset'
+          MonadOxide
+            .right('foo')
+            .inspect_left() { |_| effect = 'bar' }
+          expect(effect).to(eq('unset'))
+        }
+
+      }
+
+    }
+
+    context('#left_and_then') {
+
+      context('with a Proc') {
+
+        it('does not execute the function provided') {
+          expect(
+            MonadOxide
+              .right('foo')
+              .left_and_then(->(_) { 'bar' })
+              .unwrap_right()
+          ).to(eq('foo'))
+        }
+
+      }
+
+      context('with a block') {
+
+        it('does not execute the function provided') {
+          expect(
+            MonadOxide
+              .right('foo')
+              .left_and_then() { 'bar' }
+              .unwrap_right()
+          ).to(eq('foo'))
+        }
+
+      }
+
+    }
+
+  end
+
+  context '#match' do
+
+    it 'returns the Right branch proc\'s value' do
+      expect(
+        MonadOxide
+          .right(StandardError.new('foo'))
+          .match({
+            MonadOxide::Left => ->(_x) { 'bar' },
+            MonadOxide::Right => ->(_x) { 'error' },
+          })
+      ).to(eq('error'))
+    end
+
+    it 'operates on the Right\'s value' do
+      expect(
+        MonadOxide
+          .right(StandardError.new('foo'))
+          .match({
+            MonadOxide::Left => ->(_x) { 'bar' },
+            MonadOxide::Right => ->(x) { "#{x.to_s()}-error" },
+          })
+      ).to(eq('foo-error'))
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds the `Either` type, which has `Left` and `Right` variants as opposed to Result's `Ok` and `Err`.  This is an important distinction because there is no bias for one side over the other.

There's some additional documentation we could put into the README, and it's not on feature parity with Rust's `Either`.  It should also be noted that Rust's `Either` is not part of the core but instead a library.  Some of the function names are kind of weird (like `left_and_then` instead of `and_then_left` that would match everything else).  It's unknown why that is, and we might make an alias for it.  We might also introduce `and_then`, `map`, and other common interfaces that assume `Right`, which I'm pretty sure how Haskell does it. Aliasing methods in Ruby is cheap/easy, so this shouldn't be a problem.