### PR TITLE
add MonadOxide::Result.try

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -10,6 +10,8 @@
 ** Upcoming
 *** Breaking
 *** Additions
+1. Add ~MonadOxide::Result.try~ as a convenience to enter a ~Result~ chain.
+
 *** Fixes
 ** v0.13.0
 *** Breaking

--- a/README.org
+++ b/README.org
@@ -374,6 +374,42 @@ require 'monad-oxide'
 #+RESULTS:
 : ["bar", "qux"]
 
+*** try
+:PROPERTIES:
+:CUSTOM_ID: examples--result--try
+:END:
+
+~try~ is a way of taking some arbitrary code and converting the returned value
+into a ~Ok~ or the raised error as an ~Err~.  This is for convenience to get you
+started in a ~Result~ chain without an artificial
+~MonadOxide.ok(nil).and_then(...)~.
+
+The positive case:
+
+#+begin_src ruby :results value verbatim :exports both
+require 'monad-oxide'
+
+r = MonadOxide::Result.try(->() {
+  return 1
+})
+r.unwrap()
+#+end_src
+
+#+RESULTS:
+: 1
+
+#+begin_src ruby :results value verbatim :exports both
+require 'monad-oxide'
+
+r = MonadOxide::Result.try(->() {
+  raise StandardError.new('bar')
+})
+r.unwrap_err()
+#+end_src
+
+#+RESULTS:
+: #<StandardError: bar>
+
 *** complex operations
 :PROPERTIES:
 :CUSTOM_ID: examples--result--complex-operations

--- a/lib/result.rb
+++ b/lib/result.rb
@@ -58,6 +58,28 @@ module MonadOxide
     #   protected :new
     # end
 
+    class << self
+
+      ##
+      # Convenience for executing arbitrary code and coercing it to a Result.
+      # Any exceptions raised coerce it into an Err, and the return value is the
+      # value for the Ok.
+      # @param f [Proc<Result<A>>] The function to call. Could be a block
+      #          instead. Takes no arguments and could return any [Object].
+      # @yield Will yield a block that takes no arguments A and returns a
+      #        [Object]. Same as `f' parameter.
+      # @return [MonadOxide::Result<A, E>] An Ok if there are no exceptions
+      # raised, and an Err with the exception if any exception is raised.
+      def try(f=nil, &block)
+        begin
+          MonadOxide.ok((f || block).call())
+        rescue => e
+          MonadOxide.err(e)
+        end
+      end
+
+    end
+
     def initialize(data)
       raise NoMethodError.new('Do not use Result directly. See Ok and Err.')
     end

--- a/lib/result_spec.rb
+++ b/lib/result_spec.rb
@@ -27,4 +27,72 @@ describe MonadOxide::Result do
       expect(outer.flatten()).to(be(innermost))
     end
   end
+
+  describe('.try') {
+
+    context('with lambdas') {
+
+      it('converts a successful outcome into an Ok') {
+        r = MonadOxide::Result.try(->() {
+          return 0
+        })
+        expect(r).to(be_ok())
+      }
+
+      it('wraps the return value in the Ok') {
+        r = MonadOxide::Result.try(->() {
+          return 0
+        })
+        expect(r.unwrap()).to(be(0))
+      }
+
+      it('converts a raised error in to an Err') {
+        r = MonadOxide::Result.try(->() {
+          raise StandardError.new('foo')
+        })
+        expect(r).to(be_err())
+      }
+
+      it('wraps the raised error in the Err') {
+        r = MonadOxide::Result.try(->() {
+          raise StandardError.new('foo')
+        })
+        expect(r.unwrap_err().message()).to(eq('foo'))
+      }
+
+    }
+
+    context('with blocks') {
+
+      it('converts a successful outcome into an Ok') {
+        r = MonadOxide::Result.try() {
+          next 0
+        }
+        expect(r.unwrap()).to(be(0))
+      }
+
+      it('wraps the return value in the Ok') {
+        r = MonadOxide::Result.try() {
+          next 0
+        }
+        expect(r.unwrap()).to(be(0))
+      }
+
+      it('converts a raised error in to an Err') {
+        r = MonadOxide::Result.try() {
+          raise StandardError.new('foo')
+        }
+        expect(r).to(be_err())
+      }
+
+      it('wraps the raised error in the Err') {
+        r = MonadOxide::Result.try() {
+          raise StandardError.new('foo')
+        }
+        expect(r.unwrap_err().message()).to(eq('foo'))
+      }
+
+    }
+
+  }
 end


### PR DESCRIPTION
This adds a convenience `try` function that allows easily entering a `Result` chain.