### PR TITLE
add Option#match

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -19,6 +19,7 @@
    representing optional values.  Includes all core methods: ~some?~,
    ~none?~, ~map~, ~map_none~, ~inspect_some~, ~inspect_none~, ~and_then~,
    ~or_else~, ~unwrap~, and ~unwrap_none~.
+2. Add ~Option#match~ for pattern matching over ~Some~ and ~None~ variants.
 *** Fixes
 ** v0.14.0
 *** Breaking

--- a/README.org
+++ b/README.org
@@ -802,6 +802,39 @@ MonadOxide.option('foo').unwrap()
 #+RESULTS:
 : foo
 
+*** match
+:PROPERTIES:
+:CUSTOM_ID: examples--option--match
+:END:
+
+Pattern matching over ~Some~ and ~None~:
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.some('test')
+  .match({
+    MonadOxide::Some => ->(x) { "Value: #{x}" },
+    MonadOxide::None => ->() { "No value" }
+  })
+#+end_src
+
+#+RESULTS:
+: Value: test
+
+#+begin_src ruby :results value :exports both
+require 'monad-oxide'
+
+MonadOxide.none()
+  .match({
+    MonadOxide::Some => ->(x) { "Value: #{x}" },
+    MonadOxide::None => ->() { "No value" }
+  })
+#+end_src
+
+#+RESULTS:
+: No value
+
 * Honorable Mentions
 :PROPERTIES:
 :CUSTOM_ID: honorable-mentions

--- a/lib/none_spec.rb
+++ b/lib/none_spec.rb
@@ -190,4 +190,15 @@ describe MonadOxide::None do
 
   end
 
+  context '#match' do
+
+    it 'calls the None branch with no arguments' do
+      expect(
+        MonadOxide.none()
+          .match({ MonadOxide::None => ->() { 'default' } })
+      ).to(eq('default'))
+    end
+
+  end
+
 end

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -191,6 +191,30 @@ module MonadOxide
       raise OptionMethodNotImplementedError.new()
     end
 
+    ##
+    # Use pattern matching to work with both Some and None variants. This is
+    # useful when it is desirable to have both variants handled in the same
+    # location. It can also be useful when either variant can coerced into a
+    # non-Option type.
+    #
+    # Ruby has no built-in pattern matching, but the next best thing is a
+    # Hash using the Option classes themselves as the keys.
+    #
+    # Tests for this are found in Some and None's tests.
+    #
+    # @param matcher [Hash<Class, Proc<T, R>] matcher The matcher to match
+    # upon.
+    # @option matcher [Proc] MonadOxide::Some The branch to execute for Some.
+    # @option matcher [Proc] MonadOxide::None The branch to execute for None.
+    # @return [R] The return value of the executed Proc.
+    def match(matcher)
+      if self.kind_of?(None)
+        matcher[self.class].call()
+      else
+        matcher[self.class].call(@data)
+      end
+    end
+
   end
 
 end

--- a/lib/some_spec.rb
+++ b/lib/some_spec.rb
@@ -206,4 +206,15 @@ describe MonadOxide::Some do
 
   end
 
+  context '#match' do
+
+    it 'calls the Some branch with the data' do
+      expect(
+        MonadOxide.some('foo')
+          .match({ MonadOxide::Some => ->(x) { x.upcase() } })
+      ).to(eq('FOO'))
+    end
+
+  end
+
 end


### PR DESCRIPTION
This allows a way to express revealing both sides of the `Option` simultaneously.