### PR TITLE
flatten Promises of Arrays of Results,  Err always uses Exception

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,7 +9,14 @@
 * changelog
 ** Upcoming
 *** Breaking
+1. ~Err~ now coerces all values into a ~StandardError~ that are not ~Exception~
+   already.  This is to help with consistency of combinators.
+2. ~Array#into_result~ now looks for ~Exceptions~ and treats them as if they
+   were produced by ~Err~, which makes the combination bidirectional and
+   idempotent.
 *** Additions
+1. ~Promises~ whose results are ~Arrays~ of ~Results~ will now be flattened when
+   using ~Promise#into_result~.
 *** Fixes
 ** v0.17.0
 *** Breaking

--- a/lib/monad-oxide/array_spec.rb
+++ b/lib/monad-oxide/array_spec.rb
@@ -26,7 +26,7 @@ describe Array do
 
     end
 
-    context 'all Errs' do
+    context('all Errs') {
 
       it 'returns a single Err' do
         result = [
@@ -46,7 +46,7 @@ describe Array do
         expect(result.unwrap_err().map(&:message)).to(eq(['foo', 'bar', 'baz']))
       end
 
-    end
+    }
 
     context 'mixed Oks and Errs' do
 
@@ -77,6 +77,43 @@ describe Array do
         expect(result.unwrap_err().map(&:message)).not_to(include('baz'))
       end
     end
+
+    context('non-Result values') {
+
+      it('wraps plain values in Ok') {
+        result = [1, 2, 3].into_result()
+        expect(result.unwrap()).to(eq([1, 2, 3]))
+      }
+
+      it('wraps Exceptions in Err') {
+        result = [
+          StandardError.new('error1'),
+          StandardError.new('error2'),
+        ].into_result()
+        expect(result.unwrap_err().map(&:message)).to(eq(['error1', 'error2']))
+      }
+
+      it('treats mixed plain values and Exceptions correctly') {
+        result = [
+          1,
+          StandardError.new('error'),
+          3,
+        ].into_result()
+        expect(result.unwrap_err().map(&:message)).to(eq(['error']))
+      }
+
+      it('combines plain values, Exceptions, and Results') {
+        result = [
+          1,
+          StandardError.new('error1'),
+          MonadOxide.ok(2),
+          MonadOxide.err(StandardError.new('error2')),
+          3,
+        ].into_result()
+        expect(result.unwrap_err().map(&:message)).to(eq(['error1', 'error2']))
+      }
+
+    }
 
   end
 

--- a/lib/monad-oxide/concurrent-promises.rb
+++ b/lib/monad-oxide/concurrent-promises.rb
@@ -5,6 +5,7 @@
 
 require 'concurrent/promises'
 require_relative '../monad-oxide'
+require_relative './array'
 
 class Concurrent::Promises::Future
 
@@ -12,16 +13,27 @@ class Concurrent::Promises::Future
   # Coerces a Current::Promises::Future into a MonadOxide::Result.  This
   # behavior forces the Future to finalize, and thus is blocking behavior.
   # A successful Future becomes a MonadOxide::Ok, and a failed Future becomes a
-  # MonadOxide::Err.
+  # MonadOxide::Err.  If the Promise returns an Array of Results (either on the
+  # Err branch or the Ok branch), flatten them.
   # @return [MonadOxide::Result<A, E>] A coerced Result from the Future,
   # containing whatever value the Future was holding.
   def into_result()
     success, value, err = self.result()
-    success ? MonadOxide.ok(value) : MonadOxide.err(
-      # err isn't actually the error unless someone called rescue on the promise
-      # chain.  It's pretty weird.  So we have to check for both.
-      err.nil?() ? value : err,
+    (
+      success ? MonadOxide.ok(value) : MonadOxide.err(
+        err.nil?() ? value: err,
+      )
     )
+      .and_then(->(x) {
+        x.respond_to?(:into_result) ?
+          x.into_result() :
+          MonadOxide.ok(x)
+      })
+      .or_else(->(x) {
+        x.respond_to?(:into_result) ?
+          x.into_result() :
+          MonadOxide.err(x)
+      })
   end
 
 end

--- a/lib/monad-oxide/concurrent-promises_spec.rb
+++ b/lib/monad-oxide/concurrent-promises_spec.rb
@@ -30,6 +30,57 @@ describe(Concurrent::Promises::Future) {
       expect(result.unwrap_err().message()).to(eq('error'))
     }
 
+    it('flattens an Array of Ok Results in successful Future') {
+      result = Concurrent::Promises.future() {
+        [
+          MonadOxide.ok(1),
+          MonadOxide.ok(2),
+          MonadOxide.ok(3),
+        ]
+      }.into_result()
+      expect(result.unwrap()).to(eq([1, 2, 3]))
+    }
+
+    it('flattens an Array with mixed Results to Err in successful Future') {
+      result = Concurrent::Promises.future() {
+        [
+          MonadOxide.ok(1),
+          MonadOxide.err(StandardError.new('error1')),
+          MonadOxide.ok(3),
+          MonadOxide.err(StandardError.new('error2')),
+        ]
+      }.into_result()
+      expect(result.unwrap_err().map(&:message)).to(eq(['error1', 'error2']))
+    }
+
+    it('flattens an Array of Results in the error branch using rescue') {
+      result = Concurrent::Promises.future() {
+        raise StandardError.new('will be rescued')
+      }
+        .rescue() { |e|
+          [
+            MonadOxide.ok(1),
+            MonadOxide.err('error'),
+          ]
+        }
+        .into_result()
+      expect(result.unwrap_err().map(&:message)).to(eq(['error']))
+    }
+
+    it('preserves non-Array values in successful Future') {
+      result = Concurrent::Promises.future() {
+        42
+      }.into_result()
+      expect(result.unwrap()).to(eq(42))
+    }
+
+    it('preserves Array of non-Results in successful Future') {
+      result = Concurrent::Promises.future() {
+        [1, 2, 3]
+      }.into_result()
+      expect(result.unwrap()).to(eq([1, 2, 3]))
+    }
+
   }
 
 }

--- a/lib/monad-oxide/err.rb
+++ b/lib/monad-oxide/err.rb
@@ -20,14 +20,17 @@ module MonadOxide
     #
     # On a cursory search, this is not documented behavior.
     #
-    # @param x [Exception|T] The potential Exception to add a backtrace to, if
-    #                        it is missing a backtrace.
-    # @returns [Exception|T] The passed value, with a backtrace added if it is
-    #                        an Exception.
+    # @param x [Exception] The potential Exception to add a backtrace to, if
+    #                      it is missing a backtrace.
+    # @returns [Exception] The passed value, with a backtrace added if it is
+    #                      an Exception.  Non-Exceptions are wrapped in an
+    #                      Exception.
     def self.backtrace_fix(x)
-      if x.kind_of?(Exception) && x.backtrace.nil?
+      if  !x.kind_of?(Exception)
+        raise StandardError.new(x)
+      elsif x.kind_of?(Exception) && x.backtrace.nil?()
         raise x
-      else
+      else # Must be Exception with a backtrace already.
         x
       end
     rescue => e

--- a/lib/monad-oxide/err_spec.rb
+++ b/lib/monad-oxide/err_spec.rb
@@ -7,7 +7,7 @@ describe MonadOxide::Err do
   ctor_tests = ->(ctor) {
 
     it 'creates an Err from the data provided' do
-      expect(ctor.call('foo').unwrap_err()).to(eq('foo'))
+      expect(ctor.call('foo').unwrap_err().message()).to(eq('foo'))
     end
 
     it 'establishes a backtrace for an unraised Exception' do
@@ -451,14 +451,20 @@ describe MonadOxide::Err do
 
     context 'with Blocks' do
       it 'returns the wrapped data' do
-        expect(MonadOxide.err('foo').unwrap_err_or_else {|| 'bar'}).to(eq('foo'))
+        expect(
+          MonadOxide.err('foo')
+            .unwrap_err_or_else {|| 'bar'}
+            .message(),
+        ).to(eq('foo'))
       end
     end
 
     context 'with Procs' do
       it 'returns the wrapped data' do
         expect(
-          MonadOxide.err('foo').unwrap_err_or_else(->() {'bar'}),
+          MonadOxide.err('foo')
+            .unwrap_err_or_else(->() {'bar'})
+            .message(),
         ).to(eq('foo'))
       end
     end


### PR DESCRIPTION
Now calling `Promise#into_result` upon a `Promise<Array<Result>>` will yield a `Result<Array<A>, Array<E>>`.  This is to follow the semantics that you said you actually wanted a `Result`.

To help with consistency here, we now have `Err` coerce its non-`Exception` inputs into an `Exception` (`StandardError`).  This should help with how we treat `Array#into_result` and potentially other `#into_result` methods we might want to create.

To make semantics more consistent with `Array#into_result`, any `Exception` in the Array is treated as a failure/`Err`, and so would return an `Err`.  This allows the conversion to be bidirectional and idempotent.